### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -267,6 +267,9 @@ jobs:
 
   publish-site:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     needs:
       - framework-build
 


### PR DESCRIPTION
Potential fix for [https://github.com/Fatal1tyBarucco/design-system/security/code-scanning/30](https://github.com/Fatal1tyBarucco/design-system/security/code-scanning/30)

Add an explicit `permissions` block to the `publish-site` job in `.github/workflows/storybook.yml` (the job beginning at line 268).  
Best minimal fix without changing behavior: set `contents: read` as baseline and add only the write scope required by this job’s GitHub deployment status updates (`deployments: write`).

So update the `publish-site` job header to:

- keep existing `runs-on` and `needs`
- insert:
  - `permissions:`
    - `contents: read`
    - `deployments: write`

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
